### PR TITLE
Add new PutMany API to minimize C calls.

### DIFF
--- a/gorocksdb.c
+++ b/gorocksdb.c
@@ -244,3 +244,32 @@ extern gorocksdb_many_keys_t** gorocksdb_many_search_keys_raw(
     }
     return result;
 }
+
+void gorocksdb_writebatch_put_many(
+    rocksdb_writebatch_t* batch,
+    size_t num_pairs,
+    char** keys,
+    size_t* key_sizes,
+    char** values,
+    size_t* value_sizes
+) {
+    int i;
+    for (i=0; i < num_pairs; i++) {
+        rocksdb_writebatch_put(batch, keys[i], key_sizes[i], values[i], value_sizes[i]);
+    }
+}
+
+void gorocksdb_writebatch_put_many_cf(
+    rocksdb_writebatch_t* batch,
+    rocksdb_column_family_handle_t* cf,
+    size_t num_pairs,
+    char** keys,
+    size_t* key_sizes,
+    char** values,
+    size_t* value_sizes
+) {
+    int i;
+    for (i=0; i < num_pairs; i++) {
+        rocksdb_writebatch_put_cf(batch, cf, keys[i], key_sizes[i], values[i], value_sizes[i]);
+    }
+}

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -89,3 +89,22 @@ gorocksdb_many_keys_t** gorocksdb_many_search_keys_raw(
 );
 
 extern void gorocksdb_destroy_many_many_keys(gorocksdb_many_keys_t** many_many_keys, int size);
+
+void gorocksdb_writebatch_put_many( 
+    rocksdb_writebatch_t* batch,
+    size_t num_pairs, 
+    char** keys,
+    size_t* key_sizes, 
+    char** values, 
+    size_t* value_sizes
+);
+
+void gorocksdb_writebatch_put_many_cf( 
+    rocksdb_writebatch_t* batch,
+    rocksdb_column_family_handle_t* cf, 
+    size_t num_pairs, 
+    char** keys,
+    size_t* key_sizes, 
+    char** values, 
+    size_t* value_sizes
+);

--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package gorocksdb
 
 import "C"
 import (
+	"fmt"
 	"reflect"
 	"unsafe"
 )
@@ -37,6 +38,31 @@ func byteToChar(b []byte) *C.char {
 		c = (*C.char)(unsafe.Pointer(&b[0]))
 	}
 	return c
+}
+
+func byteSliceToArray(vals [][]byte) (**C.char, *C.size_t) {
+	if len(vals) == 0 {
+		return nil, nil
+	}
+
+	chars := make([]*C.char, len(vals))
+	sizes := make([]C.size_t, len(vals))
+	for i, val := range vals {
+		chars[i] = byteToChar(val)
+		sizes[i] = C.size_t(len(val))
+	}
+
+	cCharBuf := C.malloc(C.size_t(unsafe.Sizeof(chars[0])) * C.size_t(len(chars)))
+	copied := copy(((*[1 << 32]*C.char)(cCharBuf))[:], chars)
+	fmt.Println("COPIED X BYTES:", copied)
+
+	cChars := (**C.char)(cCharBuf)
+
+	cSizes := (*C.size_t)(unsafe.Pointer(&sizes[0]))
+	fmt.Println("sizes", sizes)
+	fmt.Println("chars", chars)
+	return cChars, cSizes
+
 }
 
 // Go []byte to C string

--- a/util.go
+++ b/util.go
@@ -2,7 +2,6 @@ package gorocksdb
 
 import "C"
 import (
-	"fmt"
 	"reflect"
 	"unsafe"
 )
@@ -53,14 +52,11 @@ func byteSliceToArray(vals [][]byte) (**C.char, *C.size_t) {
 	}
 
 	cCharBuf := C.malloc(C.size_t(unsafe.Sizeof(chars[0])) * C.size_t(len(chars)))
-	copied := copy(((*[1 << 32]*C.char)(cCharBuf))[:], chars)
-	fmt.Println("COPIED X BYTES:", copied)
+	copy(((*[1 << 32]*C.char)(cCharBuf))[:], chars)
 
 	cChars := (**C.char)(cCharBuf)
 
 	cSizes := (*C.size_t)(unsafe.Pointer(&sizes[0]))
-	fmt.Println("sizes", sizes)
-	fmt.Println("chars", chars)
 	return cChars, cSizes
 
 }

--- a/write_batch_test.go
+++ b/write_batch_test.go
@@ -41,6 +41,43 @@ func TestWriteBatch(t *testing.T) {
 	ensure.True(t, v2.Data() == nil)
 }
 
+func TestWriteBatchPutMany(t *testing.T) {
+	db := newTestDB(t, "TestWriteBatchPutMany", nil)
+	defer db.Close()
+
+	var (
+		key1 = []byte("key1")
+		val1 = []byte("val1")
+		key2 = []byte("key22")
+		val2 = []byte("val22")
+	)
+	wo := NewDefaultWriteOptions()
+	defer wo.Destroy()
+
+	// create and fill the write batch
+	keys := [][]byte{key1, key2}
+	values := [][]byte{val1, val2}
+	wb := NewWriteBatch()
+	defer wb.Destroy()
+	wb.PutMany(keys, values)
+	// ensure.DeepEqual(t, wb.Count(), 2)
+
+	// perform the batch
+	ensure.Nil(t, db.Write(wo, wb))
+
+	// check changes
+	ro := NewDefaultReadOptions()
+	v1, err := db.Get(ro, key1)
+	defer v1.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v1.Data(), val1)
+
+	v2, err := db.Get(ro, key2)
+	defer v2.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v2.Data(), val2)
+}
+
 func TestWriteBatchIterator(t *testing.T) {
 	db := newTestDB(t, "TestWriteBatchIterator", nil)
 	defer db.Close()


### PR DESCRIPTION
The original plan was to use `rocksdb_writebatch_putv`, but that did something else then assumed. So now I created a simple C API myself.