### PR TITLE
Free memory earlier for PutMany operation

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,5 +1,6 @@
 package gorocksdb
 
+// #include "stdlib.h"
 import "C"
 import (
 	"reflect"
@@ -39,7 +40,11 @@ func byteToChar(b []byte) *C.char {
 	return c
 }
 
-func byteSliceToArray(vals [][]byte) (**C.char, *C.size_t) {
+// bytesSliceToArray converts a slice of byte slices to two C arrays. One
+// containing pointers to the byte slices and one containing their sizes.
+// IMPORTANT: The **C.char array is malloced and should be freed using
+// freeCharsArray after it is used.
+func bytesSliceToArray(vals [][]byte) (**C.char, *C.size_t) {
 	if len(vals) == 0 {
 		return nil, nil
 	}
@@ -59,6 +64,11 @@ func byteSliceToArray(vals [][]byte) (**C.char, *C.size_t) {
 	cSizes := (*C.size_t)(unsafe.Pointer(&sizes[0]))
 	return cChars, cSizes
 
+}
+
+// freeCharsArray frees a **C.char that is malloced by this library itself.
+func freeCharsArray(charsArray **C.char) {
+	C.free(unsafe.Pointer(charsArray))
 }
 
 // Go []byte to C string


### PR DESCRIPTION
The values keys and values array were malloc-ed and then saved to be freed when `Destroy` is called. This is not needed, the array can be freed once the `PutMany` call is done.