### PR TITLE
GOR-1: Add MultiGet support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.6
-  - tip
+  - '1.9.3'
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/array.go
+++ b/array.go
@@ -1,6 +1,7 @@
 package gorocksdb
 
 // #include "stdlib.h"
+// #include "rocksdb/c.h"
 import "C"
 import (
 	"reflect"
@@ -9,6 +10,7 @@ import (
 
 type charsSlice []*C.char
 type sizeTSlice []C.size_t
+type columnFamilySlice []*C.rocksdb_column_family_handle_t
 
 func (s charsSlice) c() **C.char {
 	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
@@ -18,6 +20,11 @@ func (s charsSlice) c() **C.char {
 func (s sizeTSlice) c() *C.size_t {
 	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
 	return (*C.size_t)(unsafe.Pointer(sH.Data))
+}
+
+func (s columnFamilySlice) c() **C.rocksdb_column_family_handle_t {
+	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	return (**C.rocksdb_column_family_handle_t)(unsafe.Pointer(sH.Data))
 }
 
 // bytesSliceToCSlices converts a slice of byte slices to two slices with C

--- a/array.go
+++ b/array.go
@@ -1,0 +1,47 @@
+package gorocksdb
+
+// #include "stdlib.h"
+import "C"
+import (
+	"reflect"
+	"unsafe"
+)
+
+type charsSlice []*C.char
+type sizeTSlice []C.size_t
+
+func (s charsSlice) c() **C.char {
+	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	return (**C.char)(unsafe.Pointer(sH.Data))
+}
+
+func (s sizeTSlice) c() *C.size_t {
+	sH := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	return (*C.size_t)(unsafe.Pointer(sH.Data))
+}
+
+// bytesSliceToCSlices converts a slice of byte slices to two slices with C
+// datatypes. One containing pointers to copies of the byte slices and one
+// containing their sizes.
+// IMPORTANT: All the contents of the charsSlice array are malloced and
+// should be freed using the Destroy method of charsSlice.
+func byteSlicesToCSlices(vals [][]byte) (charsSlice, sizeTSlice) {
+	if len(vals) == 0 {
+		return nil, nil
+	}
+
+	chars := make(charsSlice, len(vals))
+	sizes := make(sizeTSlice, len(vals))
+	for i, val := range vals {
+		chars[i] = (*C.char)(C.CBytes(val))
+		sizes[i] = C.size_t(len(val))
+	}
+
+	return chars, sizes
+}
+
+func (s charsSlice) Destroy() {
+	for _, chars := range s {
+		C.free(unsafe.Pointer(chars))
+	}
+}

--- a/cf_handle.go
+++ b/cf_handle.go
@@ -24,3 +24,13 @@ func (h *ColumnFamilyHandle) UnsafeGetCFHandler() unsafe.Pointer {
 func (h *ColumnFamilyHandle) Destroy() {
 	C.rocksdb_column_family_handle_destroy(h.c)
 }
+
+type ColumnFamilyHandles []*ColumnFamilyHandle
+
+func (cfs ColumnFamilyHandles) toCSlice() columnFamilySlice {
+	cCFs := make(columnFamilySlice, len(cfs))
+	for i, cf := range cfs {
+		cCFs[i] = cf.c
+	}
+	return cCFs
+}

--- a/db.go
+++ b/db.go
@@ -264,7 +264,7 @@ func (db *DB) GetCF(opts *ReadOptions, cf *ColumnFamilyHandle, key []byte) (*Sli
 	return NewSlice(cValue, cValLen), nil
 }
 
-// Get returns the data associated with the key from the database.
+// MultiGet returns the data associated with the passed keys from the database
 func (db *DB) MultiGet(opts *ReadOptions, keys ...[]byte) (Slices, error) {
 	cKeys, cKeySizes := byteSlicesToCSlices(keys)
 	defer cKeys.Destroy()
@@ -275,6 +275,58 @@ func (db *DB) MultiGet(opts *ReadOptions, keys ...[]byte) (Slices, error) {
 	C.rocksdb_multi_get(
 		db.c,
 		opts.c,
+		C.size_t(len(keys)),
+		cKeys.c(),
+		cKeySizes.c(),
+		vals.c(),
+		valSizes.c(),
+		rocksErrs.c(),
+	)
+
+	var errs []error
+
+	for i, rocksErr := range rocksErrs {
+		if rocksErr != nil {
+			defer C.free(unsafe.Pointer(rocksErr))
+			err := fmt.Errorf("getting %q failed: %v", string(keys[i]), C.GoString(rocksErr))
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed to get %d keys, first error: %v", len(errs), errs[0])
+	}
+
+	slices := make(Slices, len(keys))
+	for i, val := range vals {
+		slices[i] = NewSlice(val, valSizes[i])
+	}
+
+	return slices, nil
+}
+
+// MultiGetCF returns the data associated with the passed keys from the column family
+func (db *DB) MultiGetCF(opts *ReadOptions, cf *ColumnFamilyHandle, keys ...[]byte) (Slices, error) {
+	cfs := make(ColumnFamilyHandles, len(keys))
+	for i := 0; i < len(keys); i++ {
+		cfs[i] = cf
+	}
+	return db.MultiGetCFMultiCF(opts, cfs, keys)
+}
+
+// MultiGetCFMultiCF returns the data associated with the passed keys and
+// column families.
+func (db *DB) MultiGetCFMultiCF(opts *ReadOptions, cfs ColumnFamilyHandles, keys [][]byte) (Slices, error) {
+	cKeys, cKeySizes := byteSlicesToCSlices(keys)
+	defer cKeys.Destroy()
+	vals := make(charsSlice, len(keys))
+	valSizes := make(sizeTSlice, len(keys))
+	rocksErrs := make(charsSlice, len(keys))
+
+	C.rocksdb_multi_get_cf(
+		db.c,
+		opts.c,
+		cfs.toCSlice().c(),
 		C.size_t(len(keys)),
 		cKeys.c(),
 		cKeySizes.c(),

--- a/db_test.go
+++ b/db_test.go
@@ -64,3 +64,35 @@ func newTestDB(t *testing.T, name string, applyOpts func(opts *Options)) *DB {
 
 	return db
 }
+
+func TestDBMultiGet(t *testing.T) {
+	db := newTestDB(t, "TestDBMultiGet", nil)
+	defer db.Close()
+
+	var (
+		givenKey1 = []byte("hello1")
+		givenKey2 = []byte("hello2")
+		givenKey3 = []byte("hello3")
+		givenVal1 = []byte("world1")
+		givenVal2 = []byte("world2")
+		givenVal3 = []byte("world3")
+		wo        = NewDefaultWriteOptions()
+		ro        = NewDefaultReadOptions()
+	)
+
+	// create
+	ensure.Nil(t, db.Put(wo, givenKey1, givenVal1))
+	ensure.Nil(t, db.Put(wo, givenKey2, givenVal2))
+	ensure.Nil(t, db.Put(wo, givenKey3, givenVal3))
+
+	// retrieve
+	values, err := db.MultiGet(ro, []byte("noexist"), givenKey1, givenKey2, givenKey3)
+	defer values.Destroy()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, len(values), 4)
+
+	ensure.DeepEqual(t, values[0].Data(), []byte(nil))
+	ensure.DeepEqual(t, values[1].Data(), givenVal1)
+	ensure.DeepEqual(t, values[2].Data(), givenVal2)
+	ensure.DeepEqual(t, values[3].Data(), givenVal3)
+}

--- a/slice.go
+++ b/slice.go
@@ -11,6 +11,14 @@ type Slice struct {
 	freed bool
 }
 
+type Slices []*Slice
+
+func (slices Slices) Destroy() {
+	for _, s := range slices {
+		s.Free()
+	}
+}
+
 // NewSlice returns a slice with the given data.
 func NewSlice(data *C.char, size C.size_t) *Slice {
 	return &Slice{data, size, false}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,5 @@
 package gorocksdb
 
-// #include "stdlib.h"
 import "C"
 import (
 	"reflect"
@@ -40,35 +39,6 @@ func byteToChar(b []byte) *C.char {
 	return c
 }
 
-// bytesSliceToArray converts a slice of byte slices to two C arrays. One
-// containing pointers to the byte slices and one containing their sizes.
-// IMPORTANT: The **C.char array is malloced and should be freed using
-// freeCharsArray after it is used.
-func bytesSliceToArray(vals [][]byte) (**C.char, *C.size_t) {
-	if len(vals) == 0 {
-		return nil, nil
-	}
-
-	chars, cChars := emptyCharSlice(len(vals))
-	sizes, cSizes := emptySizetSlice(len(vals))
-	for i, val := range vals {
-		chars[i] = (*C.char)(C.CBytes(val))
-		sizes[i] = C.size_t(len(val))
-	}
-
-	return cChars, cSizes
-}
-
-// freeCharsArray frees a **C.char that is malloced by this library itself.
-func freeCharsArray(charsArray **C.char, length int) {
-	var charsSlice []*C.char
-	sH := (*reflect.SliceHeader)(unsafe.Pointer(&charsSlice))
-	sH.Cap, sH.Len, sH.Data = length, length, uintptr(unsafe.Pointer(charsArray))
-	for _, chars := range charsSlice {
-		C.free(unsafe.Pointer(chars))
-	}
-}
-
 // Go []byte to C string
 // The C string is allocated in the C heap using malloc.
 func cByteSlice(b []byte) *C.char {
@@ -85,20 +55,6 @@ func cByteSlice(b []byte) *C.char {
 func stringToChar(s string) *C.char {
 	ptrStr := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	return (*C.char)(unsafe.Pointer(ptrStr.Data))
-}
-
-func emptyCharSlice(length int) (slice []*C.char, cSlice **C.char) {
-	slice = make([]*C.char, length)
-	sH := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
-	cSlice = (**C.char)(unsafe.Pointer(sH.Data))
-	return slice, cSlice
-}
-
-func emptySizetSlice(length int) (slice []C.size_t, cSlice *C.size_t) {
-	slice = make([]C.size_t, length)
-	sH := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
-	cSlice = (*C.size_t)(unsafe.Pointer(sH.Data))
-	return slice, cSlice
 }
 
 // charSlice converts a C array of *char to a []*C.char.

--- a/write_batch.go
+++ b/write_batch.go
@@ -48,15 +48,15 @@ func (wb *WriteBatch) PutMany(keys, values [][]byte) error {
 		return errors.New("Number of keys and values should be the same")
 	}
 	numPairs := C.size_t(len(keys))
-	cKeys, cKeySizes := bytesSliceToArray(keys)
-	defer freeCharsArray(cKeys, len(keys))
-	cValues, cValueSizes := bytesSliceToArray(values)
-	defer freeCharsArray(cValues, len(values))
+	cKeys, cKeySizes := byteSlicesToCSlices(keys)
+	defer cKeys.Destroy()
+	cValues, cValueSizes := byteSlicesToCSlices(values)
+	defer cValues.Destroy()
 	C.gorocksdb_writebatch_put_many(
 		wb.c,
 		numPairs,
-		cKeys, cKeySizes,
-		cValues, cValueSizes,
+		cKeys.c(), cKeySizes.c(),
+		cValues.c(), cValueSizes.c(),
 	)
 	return nil
 }
@@ -67,15 +67,15 @@ func (wb *WriteBatch) PutManyCF(cf *ColumnFamilyHandle, keys, values [][]byte) e
 		return errors.New("Number of keys and values should be the same")
 	}
 	numPairs := C.size_t(len(keys))
-	cKeys, cKeySizes := bytesSliceToArray(keys)
-	defer freeCharsArray(cKeys, len(keys))
-	cValues, cValueSizes := bytesSliceToArray(values)
-	defer freeCharsArray(cValues, len(values))
+	cKeys, cKeySizes := byteSlicesToCSlices(keys)
+	defer cKeys.Destroy()
+	cValues, cValueSizes := byteSlicesToCSlices(values)
+	defer cValues.Destroy()
 	C.gorocksdb_writebatch_put_many_cf(
 		wb.c, cf.c,
 		numPairs,
-		cKeys, cKeySizes,
-		cValues, cValueSizes,
+		cKeys.c(), cKeySizes.c(),
+		cValues.c(), cValueSizes.c(),
 	)
 	return nil
 }

--- a/write_batch.go
+++ b/write_batch.go
@@ -49,9 +49,9 @@ func (wb *WriteBatch) PutMany(keys, values [][]byte) error {
 	}
 	numPairs := C.size_t(len(keys))
 	cKeys, cKeySizes := bytesSliceToArray(keys)
-	defer freeCharsArray(cKeys)
+	defer freeCharsArray(cKeys, len(keys))
 	cValues, cValueSizes := bytesSliceToArray(values)
-	defer freeCharsArray(cValues)
+	defer freeCharsArray(cValues, len(values))
 	C.gorocksdb_writebatch_put_many(
 		wb.c,
 		numPairs,
@@ -68,9 +68,9 @@ func (wb *WriteBatch) PutManyCF(cf *ColumnFamilyHandle, keys, values [][]byte) e
 	}
 	numPairs := C.size_t(len(keys))
 	cKeys, cKeySizes := bytesSliceToArray(keys)
-	defer freeCharsArray(cKeys)
+	defer freeCharsArray(cKeys, len(keys))
 	cValues, cValueSizes := bytesSliceToArray(values)
-	defer freeCharsArray(cValues)
+	defer freeCharsArray(cValues, len(values))
 	C.gorocksdb_writebatch_put_many_cf(
 		wb.c, cf.c,
 		numPairs,


### PR DESCRIPTION
This PR does 2 things:

- It implements the MultiGet(CF) method, which can be used to retrieve a batch
  of key value pairs.
- It hardens the library to not violate as much of the CGO rules as before.
  Mainly there were some go pointers passed inside a C allocated array. This is
  disallowed and could be found by running the tests with GODEBUG=cgocheck=2.

cgocheck still complains about some other issues and I think it would be good to fix those as well in the near future. Otherwise we might get weird behaviour when the GC moves some data around or frees it.